### PR TITLE
Removed dynamic memory allocation.

### DIFF
--- a/SlowSoftWire.cpp
+++ b/SlowSoftWire.cpp
@@ -9,8 +9,9 @@
 
 #include <SlowSoftWire.h>
 
-SlowSoftWire::SlowSoftWire(uint8_t sda, uint8_t scl) {
-  si2c = new SlowSoftI2CMaster(sda, scl);
+SlowSoftWire::SlowSoftWire(uint8_t sda, uint8_t scl)
+  : si2c(sda, scl) 
+{
 }
 
 void SlowSoftWire::begin(void) {
@@ -19,11 +20,10 @@ void SlowSoftWire::begin(void) {
   error = 0;
   transmitting = false;
   
-  si2c->i2c_init();
+  si2c.i2c_init();
 }
   
 void  SlowSoftWire::end(void) {
-  free(si2c);
 }
 
 void  SlowSoftWire::setClock(uint32_t _) {
@@ -31,9 +31,9 @@ void  SlowSoftWire::setClock(uint32_t _) {
 
 void  SlowSoftWire::beginTransmission(uint8_t address) {
   if (transmitting) {
-    error = (si2c->i2c_rep_start((address<<1)|I2C_WRITE) ? 0 : 2);
+    error = (si2c.i2c_rep_start((address<<1)|I2C_WRITE) ? 0 : 2);
   } else {
-    error = (si2c->i2c_start((address<<1)|I2C_WRITE) ? 0 : 2);
+    error = (si2c.i2c_start((address<<1)|I2C_WRITE) ? 0 : 2);
   }
   // indicate that we are transmitting
   transmitting = 1;
@@ -47,7 +47,7 @@ uint8_t  SlowSoftWire::endTransmission(uint8_t sendStop)
 {
   uint8_t transError = error;
   if (sendStop) {
-    si2c->i2c_stop();
+    si2c.i2c_stop();
     transmitting = 0;
   }
   error = 0;
@@ -63,7 +63,7 @@ uint8_t  SlowSoftWire::endTransmission(void)
 }
 
 size_t  SlowSoftWire::write(uint8_t data) {
-  if (si2c->i2c_write(data)) {
+  if (si2c.i2c_write(data)) {
     return 1;
   } else {
     if (error == 0) error = 3;
@@ -100,17 +100,17 @@ uint8_t SlowSoftWire::requestFrom(uint8_t address, uint8_t quantity,
   if(quantity > BUFFER_LENGTH){
     quantity = BUFFER_LENGTH;
   }
-  localerror = !si2c->i2c_rep_start((address<<1) | I2C_READ);
+  localerror = !si2c.i2c_rep_start((address<<1) | I2C_READ);
   if (error == 0 && localerror) error = 2;
   // perform blocking read into buffer
   for (uint8_t cnt=0; cnt < quantity; cnt++) 
-    rxBuffer[cnt] = si2c->i2c_read(cnt == quantity-1);
+    rxBuffer[cnt] = si2c.i2c_read(cnt == quantity-1);
   // set rx buffer iterator vars
   rxBufferIndex = 0;
   rxBufferLength = quantity;
   if (sendStop) {
     transmitting = 0;
-    si2c->i2c_stop();
+    si2c.i2c_stop();
   }
   return quantity;
 }

--- a/SlowSoftWire.h
+++ b/SlowSoftWire.h
@@ -14,7 +14,7 @@ private:
   uint8_t rxBufferLength;
   uint8_t transmitting;
   uint8_t error;
-  SlowSoftI2CMaster *si2c;
+  SlowSoftI2CMaster si2c;
 public:
   SlowSoftWire(uint8_t sda, uint8_t scl);
   void begin(void);


### PR DESCRIPTION
Switched to using a local instance of SlowSoftI2CMaster instead of a pointer to one to avoid dynamic memory allocation. This avoids setting up a heap on small micros. 