### PR TITLE
Create library.json so can automatically load library in platformio

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,23 @@
+{
+  "name": "SlowSoftWire",
+  "keywords": "I2C",
+  "description": "local copy of SlowSoftWire",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/felias-fogg/SlowSoftWire.git"
+  },
+  "version": "1.0.0",
+  "authors":
+  [
+    {
+        "url": null,
+        "maintainer": false,
+        "email": "no idea",
+        "name": "me"
+    }
+  ],
+  "frameworks": "*",
+  "platforms": "*"
+}
+


### PR DESCRIPTION
Adding **library.json** allows automatic loading of this library into platformio.

The following lines added to platformio.ini will load the SlowSoftWire and SlowSoftI2CMaster libraries into platformio:
```
lib_deps         = felias-fogg/SlowSoftWire@^1.0.0
                   felias-fogg/SlowSoftI2CMaster@^1.0.0 
```